### PR TITLE
Use gradle vs. mvn to build ethereumj

### DIFF
--- a/master.cfg
+++ b/master.cfg
@@ -1452,14 +1452,14 @@ def ethereumj_factory(branch='master'):
         ShellCommand(
             logEnviron = False,
             name="build-ethereumj-core",
-            command=["mvn", "package"],
+            command=["./gradlew", "build"],
             workdir="build/ethereumj-core",
             decodeRC={0:SUCCESS, 1:WARNINGS, 2:WARNINGS}
         ),
         ShellCommand(
             logEnviron = False,
             name="install-ethereumj-core",
-            command=["mvn", "install"],
+            command=["./gradlew", "install"],
             workdir="build/ethereumj-core",
             decodeRC={0:SUCCESS, 1:WARNINGS, 2:WARNINGS}
         ),
@@ -1467,7 +1467,7 @@ def ethereumj_factory(branch='master'):
             haltOnFailure = True,
             logEnviron = False,
             name="build-ethereumj-studio",
-            command=["mvn", "package"],
+            command=["./gradlew", "build"],
             workdir="build/ethereumj-studio"
         )
     ]: factory.addStep(step)


### PR DESCRIPTION
This reflects changes made in ethereum/ethereumj#179, porting
ethereumj's build system from Maven to Gradle. It should fix the build
failure seen at
http://build.ethdev.com/builders/Linux%20EthereumJ%20PRs/builds/15.

Note that the command being used (`./gradlew`) is a script residing in
the root of the ethereumj repository. This means that there is no need
to install Gradle on the host machine/VM.

For complete information on Gradle and the `gradlew` script see
http://www.gradle.org and
http://www.gradle.org/docs/current/userguide/gradle_wrapper.html.
