### PR TITLE
update for keymanager

### DIFF
--- a/startup/eth-supervisord-develop.conf
+++ b/startup/eth-supervisord-develop.conf
@@ -4,4 +4,4 @@ logfile=eth-supervisord.log
 [program:eth]
 stdout_logfile=eth.log
 stderr_logfile=eth.err
-command=eth --json-rpc --client-name "Develop Server Nine" --mining off --upnp off --listen-ip 5.1.83.226
+command=eth --json-rpc --client-name "Develop Server Nine" --mining off --upnp off --listen-ip 5.1.83.226 --master 0


### PR DESCRIPTION
eth won't run without this parameter, which essentially sets and provides a default password of 0.