### PR TITLE
Change CMake build type to RelWithDebInfo for OSX with EVM JIT

### DIFF
--- a/factories/cpp_ethereum_osx.py
+++ b/factories/cpp_ethereum_osx.py
@@ -16,10 +16,11 @@ def cmake_osx_cmd(cmd=[], ccache=True, evmjit=False, headless=True):
     if headless:
         cmd.append("-DGUI=0")
     if evmjit:
-        for opt in [
+        cmd += [
+            "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
             "-DLLVM_DIR=/usr/local/opt/llvm/share/llvm/cmake",
             "-DEVMJIT=1"
-        ]: cmd.append(opt)
+        ]
     elif ccache:
         cmd.append("-DCMAKE_CXX_COMPILER=/usr/local/opt/ccache/libexec/g++")
     return cmd


### PR DESCRIPTION
That will fix the build. 

I'm investigating the problem. It looks like that some utility class of LLVM has a bug in NDEBUG version.