### PR TITLE
Second attempt at Win64 instead of Win32

### DIFF
--- a/factories/cpp_ethereum_windows.py
+++ b/factories/cpp_ethereum_windows.py
@@ -52,14 +52,14 @@ def win_cpp_factory(branch='master', isPullRequest=False):
         Configure(
             haltOnFailure=True,
             logEnviron=False,
-            command=["cmake", "."]
+            command=["cmake", ".", "-G", "Visual Studio 12 Win64"]
         ),
         MsBuild12(
             haltOnFailure=True,
             logEnviron=False,
             projectfile="ethereum.sln",
             config="release",
-            platform="Win32"
+            platform="x64"
         )
     ]: factory.addStep(step)
 
@@ -84,7 +84,7 @@ def win_cpp_factory(branch='master', isPullRequest=False):
                 descriptionDone="set filename",
                 name="set-filename",
                 property="filename",
-                value=Interpolate("AlethZero-Win32-%(kw:time_string)s-%(prop:version)s-%(prop:protocol)s-%(kw:short_revision)s.7z",
+                value=Interpolate("AlethZero-Win64-%(kw:time_string)s-%(prop:version)s-%(prop:protocol)s-%(kw:short_revision)s.7z",
                                   time_string=get_time_string,
                                   short_revision=get_short_revision)
             ),
@@ -99,14 +99,14 @@ def win_cpp_factory(branch='master', isPullRequest=False):
                 name="clean-latest-link",
                 description='cleaning latest link',
                 descriptionDone='clean latest link',
-                command=['rm', '-f', Interpolate("public_html/builds/%(prop:buildername)s/AlethZero-Win32-latest.7z")]
+                command=['rm', '-f', Interpolate("public_html/builds/%(prop:buildername)s/AlethZero-Win64-latest.7z")]
             ),
             MasterShellCommand(
                 haltOnFailure=True,
                 name="link-latest",
                 description='linking latest',
                 descriptionDone='link latest',
-                command=['ln', '-sf', Interpolate("%(prop:filename)s"), Interpolate("public_html/builds/%(prop:buildername)s/AlethZero-Win32-latest.7z")]
+                command=['ln', '-sf', Interpolate("%(prop:filename)s"), Interpolate("public_html/builds/%(prop:buildername)s/AlethZero-Win64-latest.7z")]
             )
         ]: factory.addStep(step)
 


### PR DESCRIPTION
According to
https://github.com/ethereum/cpp-ethereum/wiki/Building-on-Windows#2-generate-solution-with-cmake
when using cmake 2.8.XXX you need to provide a different argument than
when using 3.x.